### PR TITLE
Added gtm snippets to head and body of template

### DIFF
--- a/layout/_master.tmpl
+++ b/layout/_master.tmpl
@@ -10,6 +10,10 @@
 <html>
   {{>partials/head}}
   <body data-spy="scroll" data-target="#affix">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{_gtmContainerId}}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <header>
         {{^_disableNavbar}} {{>partials/navbar}} {{/_disableNavbar}}
     </header>

--- a/partials/head.tmpl.partial
+++ b/partials/head.tmpl.partial
@@ -26,4 +26,11 @@ full license information.}}
     <link rel="stylesheet" href="https://infragistics.com/css/navigation.css">
     <link rel="stylesheet" href="https://infragistics.com/css/footer.css">
     <link rel="stylesheet" href="{{_rel}}styles/main.css">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{_gtmContainerId}}');</script>
+    <!-- End Google Tag Manager -->
 </head>


### PR DESCRIPTION
Change includes the addition of the GTM snippet in the head and master templates with use of the globalmeta variable, _gtmContainerId, found in the docfx.json within Documentation repos.